### PR TITLE
BSR corrige le login lors de l'appel du callback OAuth

### DIFF
--- a/components/hoc/attach-user.js
+++ b/components/hoc/attach-user.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import User from '../../lib/user'
-import Utils from '../../lib/utils'
 
 const attachUser = Component => {
   class InnerComponent extends React.PureComponent {
@@ -14,20 +13,6 @@ const attachUser = Component => {
       const props = Component.getInitialProps ? await Component.getInitialProps(context) : {}
 
       return props
-    }
-
-    componentDidMount() {
-      const {user} = this.state
-
-      if (typeof window !== 'undefined') {
-        if (!user.loggedIn) {
-          console.log(user)
-          const token = Utils.extractTokenFromUrl(window.location.toString())
-          user.login(token).then(user => {
-            this.setState({user})
-          })
-        }
-      }
     }
 
     getChildContext() {

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,4 +1,5 @@
 import {OAUTH_ME_URI} from '@env'
+import Utils from '../lib/utils'
 
 const axios = require('axios')
 
@@ -6,6 +7,15 @@ class User {
   constructor() {
     if (typeof localStorage !== 'undefined') {
       Object.assign(this, JSON.parse(localStorage.getItem('user')) || {})
+    }
+
+    if (typeof window !== 'undefined') {
+      if (!this.loggedIn) {
+        const token = Utils.extractTokenFromUrl(window.location.toString())
+        this.login(token).then(user => {
+          Object.assign(this, user)
+        })
+      }
     }
   }
 


### PR DESCRIPTION
lorsqu'on est redirigé à partir de la fenêtre de login oauth le user présent dans le context frourni par attach user n'est pas à jour avec le state.

Je ne sais pas si les hoc sont la solution pour ce cas d'utilisation, le fix permet de fonctionner avec ce pattern